### PR TITLE
Fix Readme invalid URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You take a look to our test.
 
 Go 1.10+ must be already installed.
 ```bash
-go get -u github.com/serpapi/google_search_results_golang
+go get -u github.com/serpapi/google-search-results-golang
 ```
 
 ## Quick start


### PR DESCRIPTION
`go get -u github.com/serpapi/google_search_results_golang` is not work  
  
use `go get -u github.com/serpapi/google-search-results-golang`  

